### PR TITLE
v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2023-08-22
+
+- Install libcluster and simplify code (https://github.com/mnishiguchi/kantan_cluster/pull/3)
+
+### Breaking changes
+- removed: `:connect_to` option
+- renamed: `start` function to `start_node`
+- removed: `stop`, `connect`, `disconnect` function
+- added: `:topologies` option
+
 ## [0.4.0] - 2022-12-04
 
 - Change `node` option to explicit `name` and `sname` options
@@ -59,7 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2021-10-25
 - Initial release
 
-[Unreleased]: https://github.com/mnishiguchi/kantan_cluster/compare/v0.4.0..HEAD
+[Unreleased]: https://github.com/mnishiguchi/kantan_cluster/compare/v0.5.0..HEAD
+[0.5.0]: https://github.com/mnishiguchi/kantan_cluster/compare/v0.4.0..v0.5.0
 [0.4.0]: https://github.com/mnishiguchi/kantan_cluster/compare/v0.3.1..v0.4.0
 [0.3.1]: https://github.com/mnishiguchi/kantan_cluster/compare/v0.3.0..v0.3.1
 [0.3.0]: https://github.com/mnishiguchi/kantan_cluster/compare/v0.2.4..v0.3.0

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule KantanCluster.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.5.0"
   @source_url "https://github.com/mnishiguchi/kantan_cluster"
 
   def project do


### PR DESCRIPTION
## [0.5.0] - 2023-08-22

- Install libcluster and simplify code (https://github.com/mnishiguchi/kantan_cluster/pull/3)

### Breaking changes
- removed: `:connect_to` option
- renamed: `start` function to `start_node`
- removed: `stop`, `connect`, `disconnect` function
- added: `:topologies` option
